### PR TITLE
fix: Change input name from `github-token` to `ghToken`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Potential Conflicts Checker
 description: Check if this Pull Request can be conflict after other Pull Requests merged
 inputs:
-  github-token:
+  ghToken:
     description: The GitHub token used to create an authenticated client.
 runs:
   using: docker


### PR DESCRIPTION
Should hopefully fix issues like https://github.com/dashpay/dash/actions/runs/7122668268/job/19394069109#step:3:1

Same issue in upstream: https://github.com/outsideris/potential-conflicts-checker-action/issues/4
Same fix in upstream: https://github.com/outsideris/potential-conflicts-checker-action/pull/6

It looks like upstream is no longer updated though so proposing to fix it here.